### PR TITLE
Refinements to debug mode

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -17,11 +16,26 @@ export default class extends Controller {
     return !this.fastboot.isFastBoot && window.location.search.includes('debug');
   }
 
+  get secondsInDay() {
+    let nowTime = moment(this.now).utcOffset(ENV.APP.UTC_OFFSET).format('H:mm:ss');
+    return moment.duration(nowTime).asSeconds();
+  }
+  set secondsInDay(seconds) {
+    // Use range slider seconds with Day 1 for debug
+    let time = moment('2019-01-01').startOf('day').seconds(seconds).format('HH:mm:ss');
+    this._setFakeDayOne(time);
+    return seconds;
+  }
+
+  _setFakeDayOne(time) {
+    this.now = `2019-03-19T${time}${ENV.APP.UTC_OFFSET}`;
+  }
+
   _setNow() {
     if (ENV.APP.shouldForceDayOne) {
       // Use local clock time with Day 1 for local development
       let time = moment().format('HH:mm:ss');
-      this.now = `2019-03-19T${time}${ENV.APP.UTC_OFFSET}`;
+      this._setFakeDayOne(time);
     } else {
       // Use real date and time for non-dev environments
       this.now = moment().utcOffset(ENV.APP.UTC_OFFSET).format();
@@ -40,10 +54,5 @@ export default class extends Controller {
   constructor() {
     super(...arguments);
     this._setNow();
-  }
-
-  @action
-  setSecondsInDay(secondsString) {
-    this.now = moment('2019-03-19').hours(0).minutes(0).seconds(secondsString).format();
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -111,6 +111,39 @@ footer {
   }
 }
 
+.debug {
+  text-align: center;
+}
+
+input[type=range] {
+  -webkit-appearance: none;
+  margin: 0.5rem 0;
+  width: 100%;
+
+  &::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 0.5rem;
+    cursor: pointer;
+    background: $ember;
+  }
+  &::-webkit-slider-thumb {
+    border: solid 2px white;
+    height: 1.5rem;
+    width: 1.5rem;
+    border-radius: 0.75rem;
+    background: $ember;
+    cursor: pointer;
+    -webkit-appearance: none;
+    margin-top: -0.5rem;
+  }
+  &:focus {
+    outline: none;
+    &::-webkit-slider-runnable-track {
+      background: $ember;
+    }
+  }
+}
+
 h2 {
   margin: 0;
   padding: 1rem;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,10 +1,12 @@
 {{#if this.isDebug}}
-  <div>
+  <div class="debug">
     <input
       type="range"
       min="32400"
       max="68400"
-      {{on "input" (action this.setSecondsInDay value="target.value")}}
+      step="60"
+      value={{this.secondsInDay}}
+      {{on "input" (action (mut this.secondsInDay) value="target.value")}}
     >
     {{this.now}}
   </div>


### PR DESCRIPTION
- Sets the initial value of the debug mode range input to the current time
- Sets `step="60"` for the range slider so we're always setting round minutes (makes it easier to test session boundaries)
- Ignores local time zone in development (so that slider reflects the full range of conference Day 1)
- Adds some styling to the debug range input (it wasn't appearing at all before this in my Chrome for some reason)
- Uses a setter for `secondsInDay` rather than an action
- Refines how `moment` is used within the index controller