### PR TITLE
Refine debug experience, especially in production

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -17,7 +17,18 @@ export default class extends Controller {
   }
 
   get secondsInDay() {
-    let nowTime = moment(this.now).utcOffset(ENV.APP.UTC_OFFSET).format('H:mm:ss');
+    let nowTime;
+    let nowMoment = this._pdxMoment(this.now);
+    switch (true) {
+      case (nowMoment.isBefore('2019-03-19T09:00:00-07:00')):
+        nowTime = '09:00:00';
+        break;
+      case (nowMoment.isAfter('2019-03-19T19:00:00-07:00')):
+        nowTime = '19:00:00';
+        break;
+      default:
+        nowTime = nowMoment.format('H:mm:ss');
+    }
     return moment.duration(nowTime).asSeconds();
   }
   set secondsInDay(seconds) {
@@ -25,6 +36,10 @@ export default class extends Controller {
     let time = moment('2019-01-01').startOf('day').seconds(seconds).format('HH:mm:ss');
     this._setFakeDayOne(time);
     return seconds;
+  }
+
+  _pdxMoment(time) {
+    return moment(time).utcOffset(ENV.APP.UTC_OFFSET);
   }
 
   _setFakeDayOne(time) {
@@ -38,7 +53,7 @@ export default class extends Controller {
       this._setFakeDayOne(time);
     } else {
       // Use real date and time for non-dev environments
-      this.now = moment().utcOffset(ENV.APP.UTC_OFFSET).format();
+      this.now = this._pdxMoment().format();
     }
 
     if (!ENV.APP.shouldUpdateTime || this.fastboot.isFastBoot || this.isDebug) {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -35,6 +35,7 @@ export default class extends Controller {
     // Use range slider seconds with Day 1 for debug
     let time = moment('2019-01-01').startOf('day').seconds(seconds).format('HH:mm:ss');
     this._setFakeDayOne(time);
+    this._hasSetSeconds = true;
     return seconds;
   }
 
@@ -56,12 +57,12 @@ export default class extends Controller {
       this.now = this._pdxMoment().format();
     }
 
-    if (!ENV.APP.shouldUpdateTime || this.fastboot.isFastBoot || this.isDebug) {
+    if (!ENV.APP.shouldUpdateTime || this.fastboot.isFastBoot) {
       return;
     }
 
     window.setTimeout(() => {
-      if (this.isDestroying) { return; }
+      if (this._hasSetSeconds || this.isDestroying) { return; }
       this._setNow();
     }, 10000);
   }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,5 +1,6 @@
 {{#if this.isDebug}}
   <div class="debug">
+    {{!-- Seconds after midnight between 9AM and 7PM --}}
     <input
       type="range"
       min="32400"


### PR DESCRIPTION
- Prior to 9am on Day 1, default debug slider to min value (so we can slide forward from there)
- After 7pm on Day 1, default debug slider to max value (so we can slide back from there)
- Allow time to auto-update in debug mode until we move the slider, then stop auto-updating